### PR TITLE
FIxed ship angular_velocity calculation

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -72,7 +72,7 @@ fn create_ship(drawable: world::Drawable, world: &mut specs::World) -> specs::En
          })
          .with(world::Control {
              thrust_speed: 4.0,
-             turn_speed: -90.0,
+             turn_speed: -4.0,
          })
          .with(world::Collision {
             radius: 0.2,

--- a/src/sys/control.rs
+++ b/src/sys/control.rs
@@ -42,7 +42,7 @@ impl specs::System<super::Delta> for System {
             (w.write::<w::Inertial>(), w.read::<w::Spatial>(), w.read::<w::Control>())
         );
         for (i, s, c) in (&mut inertia, &space, &control).iter() {
-            let rotate = time * c.turn_speed * self.turn;
+            let rotate = c.turn_speed * self.turn;
             i.angular_velocity = Rad{ s: rotate };
             let dir = s.get_direction();
             let velocity = time * c.thrust_speed * self.thrust;


### PR DESCRIPTION
This fixes an issue with the ship's turn speed being tied to the FPS of the system running it. This is because  rotate is calculated as a position when it should be a velocity. Fixing this and reducing turn_speed to -4.0 should make the speed consistent regardless of FPS. 